### PR TITLE
Refactor: Translate string resources to English and add Brazilian Portuguese

### DIFF
--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1,0 +1,19 @@
+<resources>
+    <string name="app_name">ToDo Tasks</string>
+    <string name="top_app_bar_title">Minhas Tarefas</string>
+    <string name="fab_add_task_content_description">Adicionar nova tarefa</string>
+    <string name="empty_tasks_message">Você não possui atividades.\nComece criando uma agora!</string>
+    <string name="task_item_delete_button_content_description">Excluir Tarefa</string>
+    <string name="add_task_dialog_title_add">Adicionar Nova Tarefa</string>
+    <string name="add_task_dialog_title_edit">Editar Tarefa</string>
+    <string name="add_task_dialog_label_title">Título</string>
+    <string name="add_task_dialog_label_description">Descrição (Opcional)</string>
+    <string name="add_task_dialog_button_add">Adicionar</string>
+    <string name="add_task_dialog_button_save">Salvar</string>
+    <string name="dialog_button_cancel">Cancelar</string>
+    <string name="delete_confirmation_dialog_title">Confirmar Exclusão</string>
+    <string name="delete_confirmation_dialog_message">Tem certeza de que deseja excluir a tarefa
+        \"%1$s\"?
+    </string>
+    <string name="dialog_button_delete">Excluir</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,19 +1,20 @@
+<!-- /app/src/main/res/values/strings.xml -->
 <resources>
     <string name="app_name">ToDo Tasks</string>
-    <string name="top_app_bar_title">Minhas Tarefas</string>
-    <string name="fab_add_task_content_description">Adicionar nova tarefa</string>
-    <string name="empty_tasks_message">Você não possui atividades.\nComece criando uma agora!</string>
-    <string name="task_item_delete_button_content_description">Excluir Tarefa</string>
-    <string name="add_task_dialog_title_add">Adicionar Nova Tarefa</string>
-    <string name="add_task_dialog_title_edit">Editar Tarefa</string>
-    <string name="add_task_dialog_label_title">Título</string>
-    <string name="add_task_dialog_label_description">Descrição (Opcional)</string>
-    <string name="add_task_dialog_button_add">Adicionar</string>
-    <string name="add_task_dialog_button_save">Salvar</string>
-    <string name="dialog_button_cancel">Cancelar</string>
-    <string name="delete_confirmation_dialog_title">Confirmar Exclusão</string>
-    <string name="delete_confirmation_dialog_message">Tem certeza de que deseja excluir a tarefa
-        \"%1$s\"?
-    </string>
-    <string name="dialog_button_delete">Excluir</string>
+    <string name="top_app_bar_title">My Tasks</string>
+    <string name="fab_add_task_content_description">Add new task</string>
+    <string name="empty_tasks_message">You have no tasks.\nStart by creating one now!</string>
+    <string name="task_item_delete_button_content_description">Delete Task</string>
+    <string name="add_task_dialog_title_add">Add New Task</string>
+    <string name="add_task_dialog_title_edit">Edit Task</string>
+    <string name="add_task_dialog_label_title">Title</string>
+    <string name="add_task_dialog_label_description">Description (Optional)</string>
+    <string name="add_task_dialog_button_add">Add</string>
+    <string name="add_task_dialog_button_save">Save</string>
+    <string name="dialog_button_cancel">Cancel</string>
+    <string name="delete_confirmation_dialog_title">Confirm Deletion</string>
+    <string name="delete_confirmation_dialog_message">Are you sure you want to delete the task
+            \"%1$s\"?
+        </string>
+    <string name="dialog_button_delete">Delete</string>
 </resources>


### PR DESCRIPTION
This Pull Request changes the default string resources to English and introduces a new `strings.xml` file for Brazilian Portuguese (pt-BR) localization.

Changes:
- Modified `app/src/main/res/values/strings.xml`:
    - Translated all existing string values from Portuguese to English.
    - Added a comment indicating the file path.
- Created `app/src/main/res/values-pt-rBR/strings.xml`:
    - Added a new strings file containing the original Portuguese translations.